### PR TITLE
Rename metric gpbackup_backup_deleted_status.

### DIFF
--- a/e2e_tests/run_e2e.sh
+++ b/e2e_tests/run_e2e.sh
@@ -40,7 +40,7 @@ esac
 # A simple test to check the number of metrics.
 # Format: regex for metric | repetitions.
 declare -a REGEX_LIST=(
-    '^gpbackup_backup_deleted_status{.*}|7'
+    '^gpbackup_backup_deletion_status{.*}|7'
     '^gpbackup_backup_duration_seconds{.*object_filtering="none",plugin="none".*}|5'
     '^gpbackup_backup_duration_seconds{.*object_filtering="include-table",plugin="gpbackup_s3_plugin".*}|2'
     '^gpbackup_backup_duration_seconds{.*}|7'

--- a/gpbckpexporter/gpbckp_backup_metrics.go
+++ b/gpbckpexporter/gpbckp_backup_metrics.go
@@ -22,7 +22,7 @@ var (
 			"plugin",
 			"timestamp"})
 	gpbckpBackupDataDeletedStatusMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "gpbackup_backup_deleted_status",
+		Name: "gpbackup_backup_deletion_status",
 		Help: "Backup deletion status.",
 	},
 		[]string{
@@ -63,7 +63,7 @@ var (
 
 // Set backup metrics:
 //   - gpbackup_backup_status
-//   - gpbackup_backup_deleted_status
+//   - gpbackup_backup_deletion_status
 //   - gpbackup_backup_info
 //   - gpbackup_backup_duration_seconds
 func getBackupMetrics(backupData gpbckpconfig.BackupConfig, setUpMetricValueFun setUpMetricValueFunType, logger log.Logger) {
@@ -103,7 +103,7 @@ func getBackupMetrics(backupData gpbckpconfig.BackupConfig, setUpMetricValueFun 
 	// Backup deletion status.
 	setUpMetric(
 		gpbckpBackupDataDeletedStatusMetric,
-		"gpbackup_backup_deleted_status",
+		"gpbackup_backup_deletion_status",
 		bckpDeletedStatus,
 		setUpMetricValueFun,
 		logger,

--- a/gpbckpexporter/gpbckp_backup_metrics_test.go
+++ b/gpbckpexporter/gpbckp_backup_metrics_test.go
@@ -21,9 +21,9 @@ func TestGetBackupMetrics(t *testing.T) {
 		setUpMetricValueFun setUpMetricValueFunType
 		testText            string
 	}
-	templateMetrics := `# HELP gpbackup_backup_deleted_status Backup deletion status.
-# TYPE gpbackup_backup_deleted_status gauge
-gpbackup_backup_deleted_status{backup_type="full",database_name="test",date_deleted="none",object_filtering="none",plugin="none",timestamp="20230118152654"} 0
+	templateMetrics := `# HELP gpbackup_backup_deletion_status Backup deletion status.
+# TYPE gpbackup_backup_deletion_status gauge
+gpbackup_backup_deletion_status{backup_type="full",database_name="test",date_deleted="none",object_filtering="none",plugin="none",timestamp="20230118152654"} 0
 # HELP gpbackup_backup_duration_seconds Backup duration.
 # TYPE gpbackup_backup_duration_seconds gauge
 gpbackup_backup_duration_seconds{backup_type="full",database_name="test",end_time="20230118152656",object_filtering="none",plugin="none",timestamp="20230118152654"} 2

--- a/gpbckpexporter/gpbckp_exporter_test.go
+++ b/gpbckpexporter/gpbckp_exporter_test.go
@@ -116,11 +116,11 @@ func TestGetGPBackupInfo(t *testing.T) {
 				0,
 			},
 			`level=debug msg="Set up metric" metric=gpbackup_backup_status value=0 labels=full,test,none,none,20230118152654
-level=debug msg="Set up metric" metric=gpbackup_backup_deleted_status value=0 labels=full,test,none,none,none,20230118152654
+level=debug msg="Set up metric" metric=gpbackup_backup_deletion_status value=0 labels=full,test,none,none,none,20230118152654
 level=debug msg="Set up metric" metric=gpbackup_backup_info value=1 labels=/data/backups,1.26.0,full,gzip,test,6.23.0,none,none,none,20230118152654,false
 level=debug msg="Set up metric" metric=gpbackup_backup_duration_seconds value=2 labels=full,test,20230118152656,none,none,20230118152654
 level=debug msg="Set up metric" metric=gpbackup_backup_status value=0 labels=metadata-only,test,none,none,20230118162654
-level=debug msg="Set up metric" metric=gpbackup_backup_deleted_status value=0 labels=metadata-only,test,none,none,none,20230118162654
+level=debug msg="Set up metric" metric=gpbackup_backup_deletion_status value=0 labels=metadata-only,test,none,none,none,20230118162654
 level=debug msg="Set up metric" metric=gpbackup_backup_info value=1 labels=/data/backups,1.26.0,metadata-only,gzip,test,6.23.0,none,none,none,20230118162654,false
 level=debug msg="Set up metric" metric=gpbackup_backup_duration_seconds value=2 labels=metadata-only,test,20230118162656,none,none,20230118162654
 `,


### PR DESCRIPTION
The metric `gpbackup_backup_deleted_status` was renamed to `gpbackup_backup_deletion_status`.

The metric is described correctly in the documentation, but the old metric name was in the code. The exporter gave away the old metric. This has been fixed.