### PR TITLE
Fix gpbackup_backup_since_last_completion_seconds metric.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The description of TLS configuration and basic authentication can be found at [e
 ### Building and running docker
 
 Environment variables supported by this image:
+* `TZ` - container's time zone, default `Etc/UTC`;
 * `EXPORTER_ENDPOINT` - metrics endpoint, default `/metrics`;
 * `EXPORTER_PORT` - port for prometheus metrics to listen on, default `19854`;
 * `EXPORTER_CONFIG` - path to the configuration file for TLS and/or basic authentication, default `""`;
@@ -114,6 +115,8 @@ Environment variables supported by this image:
 * `DB_INCLUDE` - specific database for collecting metrics, default `""`;
 * `DB_EXCLUDE` - specific database to exclude from collecting metrics, default `""`;
 * `BACKUP_TYPE` - specific backup type for collecting metrics, default `""`.
+
+When running exporter in docker, it is necessary to specify correct timezone via `TZ` variable. The timestamp values in the history database are stored taking into account the timezone in which Greenplum cluster operates. Otherwise, there may be incorrect values for `gpbackup_backup_since_last_completion_seconds` metric.
 
 #### Pull
 
@@ -144,6 +147,7 @@ Simple run:
 ```bash
 docker run -d --restart=always \
     --name gpbackup_exporter \
+    -e TZ=America/Chicago \
     -e HISTORY_FILE=/data/gpbackup_history.yaml \
     -p 19854:19854 \
     -v /data/master/gpseg-1/gpbackup_history.yaml:/data/gpbackup_history.yaml:ro \

--- a/docker_files/entrypoint.sh
+++ b/docker_files/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+uid=$(id -u)
+
+if [ "${uid}" = "0" ]; then
+    # Custom time zone.
+    if [ "${TZ}" != "Etc/UTC" ]; then
+        cp /usr/share/zoneinfo/${TZ} /etc/localtime
+        echo "${TZ}" > /etc/timezone
+    fi
+fi
+
+if [ "${uid}" = "0" ]; then
+    # Use nobody user.
+    exec su-exec nobody "$@"
+else
+    exec "$@"
+fi

--- a/gpbckpexporter/gpbckp_exporter.go
+++ b/gpbckpexporter/gpbckp_exporter.go
@@ -100,7 +100,12 @@ func GetGPBackupInfo(historyFile, backupType string, collectDeleted, collectFail
 						if err != nil {
 							level.Error(logger).Log("msg", "Parse backup timestamp value failed", "err", err)
 						}
-						bckpStopTime, err := time.Parse(gpbckpconfig.Layout, parseHData.BackupConfigs[i].EndTime)
+						// History file contains backup end time with timezone information.
+						// See https://github.com/greenplum-db/gpbackup/blob/722899aada32ec118eb311255ac521b691bb4360/backup/backup.go#L431-L432
+						// It is necessary to take this into account when calculating time intervals.
+						// With a high probability, the exporter will work in the same timezone as Greenplum cluster.
+						// If this is not the case, then there are many questions about the backup process.
+						bckpStopTime, err := time.ParseInLocation(gpbckpconfig.Layout, parseHData.BackupConfigs[i].EndTime, time.Local)
 						if err != nil {
 							level.Error(logger).Log("msg", "Parse backup end time value failed", "err", err)
 						}


### PR DESCRIPTION
It wasn't taken into account that endtime already contains a timezone. Therefore, the `gpbackup_backup_since_last_completion_seconds` metric showed incorrect values if the Greenplum cluster works not in UTC timezone.

With a high probability, the exporter will work in the same timezone as Greenplum cluster. Added accounting for the local timezone when parsing the endtime value.

When running exporter in docker, it is necessary to specify correct timezone via `TZ` variable.